### PR TITLE
Refactor: Remove old vote_id from opinions

### DIFF
--- a/lib/you_congress/digital_twins.ex
+++ b/lib/you_congress/digital_twins.ex
@@ -81,7 +81,6 @@ defmodule YouCongress.DigitalTwins do
           opinion_id: opinion.id
         })
 
-      Opinions.update_opinion(opinion, %{vote_id: vote.id})
       {:ok, vote}
     else
       #  Set the author as twin_origin so it won't be used again and do not save

--- a/lib/you_congress/opinions/opinion.ex
+++ b/lib/you_congress/opinions/opinion.ex
@@ -16,7 +16,6 @@ defmodule YouCongress.Opinions.Opinion do
 
     belongs_to :author, YouCongress.Authors.Author
     belongs_to :user, YouCongress.Accounts.User
-    belongs_to :vote, YouCongress.Votes.Vote
     belongs_to :voting, YouCongress.Votings.Voting
 
     timestamps()
@@ -32,8 +31,7 @@ defmodule YouCongress.Opinions.Opinion do
       :author_id,
       :user_id,
       :voting_id,
-      :ancestry,
-      :vote_id
+      :ancestry
     ])
     |> validate_required([:content, :twin])
     |> validate_source_url_if_present()

--- a/lib/you_congress/votes.ex
+++ b/lib/you_congress/votes.ex
@@ -34,6 +34,12 @@ defmodule YouCongress.Votes do
       opts,
       base_query,
       fn
+        {:author_ids, author_ids}, query ->
+          where(query, [v], v.author_id in ^author_ids)
+
+        {:voting_ids, voting_ids}, query ->
+          where(query, [v], v.voting_id in ^voting_ids)
+
         {:twin, twin}, query ->
           where(query, [v], v.twin == ^twin)
 

--- a/lib/you_congress_web/live/home_live/index.ex
+++ b/lib/you_congress_web/live/home_live/index.ex
@@ -26,40 +26,74 @@ defmodule YouCongressWeb.HomeLive.Index do
 
   @impl true
   def handle_params(_params, _, socket) do
+    socket =
+      socket
+      |> load_opinions_and_votes()
+      |> assign(
+        page_title: "Home",
+        page: 1
+      )
+
+    {:noreply, socket}
+  end
+
+  defp load_opinions_and_votes(socket) do
     opinions =
       Opinions.list_opinions(
-        preload: [:voting, :author, vote: [:answer]],
+        preload: [:voting, :author],
         twin: false,
         order_by: [desc: :updated_at],
         limit: @per_page
       )
 
-    socket =
-      socket
-      |> stream(:opinions, opinions)
-      |> assign(page_title: "Home", page: 1, no_more_opinions?: length(opinions) < @per_page)
+    votes = get_votes(opinions)
 
-    {:noreply, socket}
+    socket
+    |> stream(:opinions, opinions)
+    |> assign(votes: votes)
+    |> assign(no_more_opinions?: length(opinions) < @per_page)
+  end
+
+  defp get_votes(opinions) do
+    voting_ids = Enum.map(opinions, & &1.voting_id)
+    author_ids = Enum.map(opinions, & &1.author_id)
+
+    votes = Votes.list_votes(voting_ids: voting_ids, author_ids: author_ids, preload: [:answer])
+
+    votes =
+      Enum.reduce(opinions, %{}, fn opinion, acc ->
+        vote =
+          Enum.find(votes, fn v ->
+            v.voting_id == opinion.voting_id && v.author_id == opinion.author_id
+          end)
+
+        Map.put(acc, opinion.id, vote)
+      end)
+
+    votes
   end
 
   @impl true
   def handle_event("load-more", _, socket) do
-    %{assigns: %{page: page}} = socket
+    %{assigns: %{page: page, votes: votes}} = socket
     new_page = page + 1
     offset = (new_page - 1) * @per_page
 
     opinions =
       Opinions.list_opinions(
-        preload: [:voting, :author, vote: [:answer]],
+        preload: [:voting, :author],
         twin: false,
         order_by: [desc: :updated_at],
         limit: @per_page,
         offset: offset
       )
 
+    votes = Map.merge(votes, get_votes(opinions))
+
     socket =
       socket
       |> stream(:opinions, opinions)
+      |> assign(votes: votes)
       |> assign(page: new_page, no_more_opinions?: length(opinions) < @per_page)
 
     {:noreply, socket}

--- a/lib/you_congress_web/live/home_live/index.html.heex
+++ b/lib/you_congress_web/live/home_live/index.html.heex
@@ -13,6 +13,7 @@
 
 <ul class="pt-6" phx-update="stream" phx-viewport-bottom="load-more" id="activity">
   <%= for {_id, opinion} <- @streams.opinions do %>
+    <% vote = @votes[opinion.id] %>
     <li class="pb-4" id={"opinion-#{opinion.id}"}>
       <strong>
         <.link patch={~p"/v/#{opinion.voting.slug}"}><%= opinion.voting.title %></.link>
@@ -21,15 +22,15 @@
         <.link href={AuthorShow.author_path(opinion.author)}>
           <%= opinion.author.name || "Anonymous" %>
         </.link>
-        <%= if opinion.vote && Votes.public?(opinion.vote) do %>
+        <%= if vote && Votes.public?(vote) do %>
           <%= VoteComponent.response_with_s(
             assigns,
-            opinion.vote.answer.response
+            vote.answer.response
           ) %>
-          <%= unless opinion.vote.direct do %>
+          <%= unless vote.direct do %>
             via delegates
           <% end %>
-          <%= if opinion.vote.opinion do %>
+          <%= if vote.opinion do %>
             and says:
           <% end %>
         <% else %>

--- a/lib/you_congress_web/live/voting_live/show/comments.ex
+++ b/lib/you_congress_web/live/voting_live/show/comments.ex
@@ -99,7 +99,6 @@ defmodule YouCongressWeb.VotingLive.Show.Comments do
       content: opinion_content,
       author_id: current_user_vote.author_id,
       user_id: socket.assigns.current_user.id,
-      vote_id: current_user_vote.id,
       twin: false,
       voting_id: voting.id
     }

--- a/priv/repo/migrations/20240326114137_populate_opinions.exs
+++ b/priv/repo/migrations/20240326114137_populate_opinions.exs
@@ -8,8 +8,7 @@ defmodule YouCongress.Repo.Migrations.PopulateOpinions do
           content: vote.opinion,
           source_url: vote.source_url,
           author_id: vote.author_id,
-          user_id: nil,
-          vote_id: vote.id
+          user_id: nil
         })
 
       YouCongress.Votes.update_vote(vote, %{opinion_id: opinion.id})

--- a/priv/repo/migrations/20240706085923_remove_vote_id_from_opinions.exs
+++ b/priv/repo/migrations/20240706085923_remove_vote_id_from_opinions.exs
@@ -1,0 +1,9 @@
+defmodule YouCongress.Repo.Migrations.RemoveVoteIdFromOpinions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:opinions) do
+      remove :vote_id
+    end
+  end
+end

--- a/test/support/fixtures/opinions_fixtures.ex
+++ b/test/support/fixtures/opinions_fixtures.ex
@@ -4,13 +4,12 @@ defmodule YouCongress.OpinionsFixtures do
   entities via the `YouCongress.Opinions` context.
   """
 
-  alias YouCongress.{VotingsFixtures, AccountsFixtures, VotesFixtures, AuthorsFixtures}
+  alias YouCongress.{VotingsFixtures, AccountsFixtures, AuthorsFixtures}
 
   @doc """
   Generate an opinion.
   """
-  def opinion_fixture(attrs \\ %{}, generate_vote \\ false) do
-    generate_vote = if generate_vote, do: true, else: nil
+  def opinion_fixture(attrs \\ %{}) do
     voting_id = attrs[:voting_id] || VotingsFixtures.voting_fixture().id
     author_id = attrs[:author_id] || AuthorsFixtures.author_fixture().id
     user_id = attrs[:user_id] || AccountsFixtures.user_fixture(%{author_id: author_id}).id
@@ -23,17 +22,7 @@ defmodule YouCongress.OpinionsFixtures do
         twin: true,
         voting_id: voting_id,
         user_id: user_id,
-        author_id: author_id,
-        vote_id:
-          generate_vote &&
-            VotesFixtures.vote_fixture(
-              %{
-                voting_id: voting_id,
-                user_id: user_id,
-                author_id: author_id
-              },
-              false
-            ).id
+        author_id: author_id
       })
       |> YouCongress.Opinions.create_opinion()
 

--- a/test/support/fixtures/votes_fixtures.ex
+++ b/test/support/fixtures/votes_fixtures.ex
@@ -8,7 +8,6 @@ defmodule YouCongress.VotesFixtures do
   import YouCongress.VotingsFixtures
   import YouCongress.Votes.AnswersFixtures
   import YouCongress.OpinionsFixtures
-  alias YouCongress.Opinions
   alias YouCongress.Votes
 
   @doc """
@@ -26,13 +25,8 @@ defmodule YouCongress.VotesFixtures do
         answer_id: answer_fixture().id
       })
 
-    #  This should be fixed
-    #  A vote has an opinion_id and an opinion has a vote_id
-    #  This is because, at the moment, all root opinions belong to a vote
-    #  and a vote displays a single opinion per user in a given voting
-    {attrs, opinion} = add_opinion_if_not_present(attrs, voting_id, generate_opinion)
+    {attrs, _opinion} = add_opinion_if_not_present(attrs, voting_id, generate_opinion)
     {:ok, vote} = Votes.create_vote(attrs)
-    if opinion, do: Opinions.update_opinion(opinion, %{vote_id: vote.id})
 
     vote
   end
@@ -41,7 +35,7 @@ defmodule YouCongress.VotesFixtures do
     if !generate_opinion || attrs[:opinion_id] do
       {attrs, nil}
     else
-      opinion = opinion_fixture(%{voting_id: voting_id}, false)
+      opinion = opinion_fixture(%{voting_id: voting_id})
       attrs = attrs |> Map.put(:opinion_id, opinion.id)
       {attrs, opinion}
     end

--- a/test/you_congress_web/live/add_quote_live_test.exs
+++ b/test/you_congress_web/live/add_quote_live_test.exs
@@ -48,7 +48,6 @@ defmodule YouCongressWeb.AddQuoteLiveTest do
       assert opinion.author_id == author.id
       assert opinion.content == "Democracy is essential."
       assert opinion.source_url == "http://example.com/democracy_quote"
-      assert opinion.vote_id == vote.id
       assert opinion.user_id == current_user.id
       assert opinion.twin == false
     end
@@ -93,7 +92,6 @@ defmodule YouCongressWeb.AddQuoteLiveTest do
       assert opinion.author_id == author.id
       assert opinion.content == "Democracy is essential."
       assert opinion.source_url == "http://example.com/democracy_quote"
-      assert opinion.vote_id == vote.id
       assert opinion.user_id == current_user.id
       assert opinion.twin == false
 
@@ -122,7 +120,6 @@ defmodule YouCongressWeb.AddQuoteLiveTest do
       assert opinion.author_id == author.id
       assert opinion.content == "Democracy is essential 2."
       assert opinion.source_url == "http://example.com/democracy_quote2"
-      assert opinion.vote_id == vote.id
       assert opinion.user_id == current_user.id
       assert opinion.twin == false
     end
@@ -187,7 +184,6 @@ defmodule YouCongressWeb.AddQuoteLiveTest do
       assert opinion.author_id == author.id
       assert opinion.content == "Democracy is essential."
       assert opinion.source_url == "http://example.com/democracy_quote"
-      assert opinion.vote_id == vote.id
       assert opinion.user_id == current_user.id
       assert opinion.twin == false
     end

--- a/test/you_congress_web/live/voting_live_test.exs
+++ b/test/you_congress_web/live/voting_live_test.exs
@@ -10,7 +10,6 @@ defmodule YouCongressWeb.VotingLiveTest do
   alias YouCongress.VotesFixtures
   alias YouCongress.OpinionsFixtures
   alias YouCongress.Votings
-  alias YouCongress.Opinions
 
   @create_attrs %{title: "nuclear energy"}
   @suggested_titles [
@@ -137,7 +136,6 @@ defmodule YouCongressWeb.VotingLiveTest do
       opinion = OpinionsFixtures.opinion_fixture(%{voting_id: voting.id})
       #  Create a vote so we display the voting options
       VotesFixtures.vote_fixture(%{voting_id: voting.id, opinion_id: opinion.id})
-      Opinions.update_opinion(opinion, %{vote_id: opinion.vote_id})
 
       {:ok, show_live, _html} = live(conn, ~p"/v/#{voting.slug}")
 
@@ -262,8 +260,6 @@ defmodule YouCongressWeb.VotingLiveTest do
         opinion_id: opinion.id
       })
 
-      Opinions.update_opinion(opinion, %{vote_id: opinion.vote_id})
-
       {:ok, show_live, _html} = live(conn, ~p"/v/#{voting.slug}")
 
       show_live
@@ -287,28 +283,21 @@ defmodule YouCongressWeb.VotingLiveTest do
       conn = log_in_user(conn, user)
 
       opinion =
-        OpinionsFixtures.opinion_fixture(
-          %{
-            author_id: user.author_id,
-            user_id: user.id,
-            voting_id: voting.id,
-            content: "whatever",
-            twin: false
-          },
-          false
-        )
-
-      vote =
-        VotesFixtures.vote_fixture(%{
-          voting_id: voting.id,
+        OpinionsFixtures.opinion_fixture(%{
           author_id: user.author_id,
-          opinion_id: opinion.id,
           user_id: user.id,
+          voting_id: voting.id,
+          content: "whatever",
           twin: false
         })
 
-      {:ok, _opinion} =
-        Opinions.update_opinion(opinion, %{vote_id: vote.id})
+      VotesFixtures.vote_fixture(%{
+        voting_id: voting.id,
+        author_id: user.author_id,
+        opinion_id: opinion.id,
+        user_id: user.id,
+        twin: false
+      })
 
       #  Create an AI generated comment as we don't display the form until we have one of these
       VotesFixtures.vote_fixture(%{twin: true, voting_id: voting.id}, true)


### PR DESCRIPTION
vote_id is not necessary anymore because now the opinions table has voting_id and author_id.
Also, it became a circular dependency as votes now have an opinion_id.