### PR TITLE
Fix typo in faq

### DIFF
--- a/lib/you_congress_web/controllers/page_html/faq.html.heex
+++ b/lib/you_congress_web/controllers/page_html/faq.html.heex
@@ -51,7 +51,7 @@
           <p class="text-base leading-7 text-gray-600">
             YouCongress users can choose a list of delegates, similar to following others on social media.
             However, here, users' votes align with the majority of their delegates unless they vote personally.
-            For example, if a user has five delegates who hpt-4ave voted on an issue, and three of them vote in favor while two vote against, the user's vote will automatically be in favor too. This holds unless the user votes directly, in which case the delegates' votes don't matter.
+            For example, if a user has five delegates who have voted on an issue, and three of them vote in favor while two vote against, the user's vote will automatically be in favor too. This holds unless the user votes directly, in which case the delegates' votes don't matter.
           </p>
           <p class="text-base leading-7 text-gray-600 ">
             Future enhancements will introduce additional delegation models, including topic-specific delegation. This will enable users to appoint delegates for votes concerning specific areas such as their local community, economic matters, AI-related issues, and more.


### PR DESCRIPTION
Removes strange “pt-4” artifact in the middle of one of the FAQ answers.